### PR TITLE
Add Tracking Error Details to SDK Response

### DIFF
--- a/src/Api/Data/Response/Tracking/TrackingInfoInterface.php
+++ b/src/Api/Data/Response/Tracking/TrackingInfoInterface.php
@@ -7,7 +7,6 @@ namespace Dhl\Express\Api\Data\Response\Tracking;
 use Dhl\Express\Api\Data\Response\Tracking\TrackingInfo\PieceInterface;
 use Dhl\Express\Api\Data\Response\Tracking\TrackingInfo\ShipmentDetailsInterface;
 use Dhl\Express\Api\Data\Response\Tracking\TrackingInfo\ShipmentEventInterface;
-use Dhl\Express\Webservice\Soap\Type\Tracking\ConditionCollection;
 
 /**
  * TrackingInfo class.
@@ -56,13 +55,22 @@ interface TrackingInfoInterface
     public function getPieces();
 
     /**
-     * @return ConditionCollection
+     * @return string[]
      */
     public function getAwbConditions();
 
     /**
-     * @param ConditionCollection $awbConditions
+     * array of code=>message
+     * @param string[] $awbConditions
+     * @return self
      */
     public function setAwbConditions($awbConditions);
+
+    /**
+     * @param string $conditionCode
+     * @param string $conditionDescription
+     * @return self
+     */
+    public function addAwbConditions($conditionCode, $conditionDescription);
 
 }

--- a/src/Api/Data/Response/Tracking/TrackingInfoInterface.php
+++ b/src/Api/Data/Response/Tracking/TrackingInfoInterface.php
@@ -7,6 +7,7 @@ namespace Dhl\Express\Api\Data\Response\Tracking;
 use Dhl\Express\Api\Data\Response\Tracking\TrackingInfo\PieceInterface;
 use Dhl\Express\Api\Data\Response\Tracking\TrackingInfo\ShipmentDetailsInterface;
 use Dhl\Express\Api\Data\Response\Tracking\TrackingInfo\ShipmentEventInterface;
+use Dhl\Express\Webservice\Soap\Type\Tracking\ConditionCollection;
 
 /**
  * TrackingInfo class.
@@ -53,4 +54,15 @@ interface TrackingInfoInterface
      * @return PieceInterface[]
      */
     public function getPieces();
+
+    /**
+     * @return ConditionCollection
+     */
+    public function getAwbConditions();
+
+    /**
+     * @param ConditionCollection $awbConditions
+     */
+    public function setAwbConditions($awbConditions);
+
 }

--- a/src/Model/Response/Tracking/TrackingInfo.php
+++ b/src/Model/Response/Tracking/TrackingInfo.php
@@ -8,7 +8,6 @@ use Dhl\Express\Api\Data\Response\Tracking\TrackingInfo\PieceInterface;
 use Dhl\Express\Api\Data\Response\Tracking\TrackingInfo\ShipmentDetailsInterface;
 use Dhl\Express\Api\Data\Response\Tracking\TrackingInfo\ShipmentEventInterface;
 use Dhl\Express\Api\Data\Response\Tracking\TrackingInfoInterface;
-use Dhl\Express\Webservice\Soap\Type\Tracking\ConditionCollection;
 
 /**
  * TrackingInfo.
@@ -28,9 +27,11 @@ class TrackingInfo implements TrackingInfoInterface
      */
     private $awbStatus;
     /**
-     * @var ConditionCollection
+     * @var string[]
+     * code => message
+     * [101=>'error_description']
      */
-    private $awbConditions;
+    public $awbConditions = [];
 
     /**
      * @var ShipmentDetailsInterface
@@ -52,7 +53,6 @@ class TrackingInfo implements TrackingInfoInterface
      *
      * @param string                   $awbNumber
      * @param string                   $awbStatus
-     * @param ConditionCollection      $awbConditions
      * @param ShipmentDetailsInterface $shipmentDetails
      * @param ShipmentEventInterface[] $shipmentEvents
      * @param PieceInterface[]         $pieces
@@ -60,14 +60,12 @@ class TrackingInfo implements TrackingInfoInterface
     public function __construct(
         $awbNumber,
         $awbStatus,
-        $awbConditions,
         ShipmentDetailsInterface $shipmentDetails,
         array $shipmentEvents,
         array $pieces
     ) {
         $this->awbNumber = $awbNumber;
         $this->awbStatus = $awbStatus;
-        $this->awbConditions = $awbConditions;
         $this->shipmentDetails = $shipmentDetails;
         $this->shipmentEvents = $shipmentEvents;
         $this->pieces = $pieces;
@@ -106,5 +104,12 @@ class TrackingInfo implements TrackingInfoInterface
     public function setAwbConditions($awbConditions)
     {
         $this->awbConditions = $awbConditions;
+        return $this;
+    }
+
+    public function addAwbConditions($conditionCode, $conditionDescription)
+    {
+        $this->awbConditions[$conditionCode] = $conditionDescription;
+        return $this;
     }
 }

--- a/src/Model/Response/Tracking/TrackingInfo.php
+++ b/src/Model/Response/Tracking/TrackingInfo.php
@@ -8,6 +8,7 @@ use Dhl\Express\Api\Data\Response\Tracking\TrackingInfo\PieceInterface;
 use Dhl\Express\Api\Data\Response\Tracking\TrackingInfo\ShipmentDetailsInterface;
 use Dhl\Express\Api\Data\Response\Tracking\TrackingInfo\ShipmentEventInterface;
 use Dhl\Express\Api\Data\Response\Tracking\TrackingInfoInterface;
+use Dhl\Express\Webservice\Soap\Type\Tracking\ConditionCollection;
 
 /**
  * TrackingInfo.
@@ -26,6 +27,10 @@ class TrackingInfo implements TrackingInfoInterface
      * @var string
      */
     private $awbStatus;
+    /**
+     * @var ConditionCollection
+     */
+    private $awbConditions;
 
     /**
      * @var ShipmentDetailsInterface
@@ -47,6 +52,7 @@ class TrackingInfo implements TrackingInfoInterface
      *
      * @param string                   $awbNumber
      * @param string                   $awbStatus
+     * @param ConditionCollection      $awbConditions
      * @param ShipmentDetailsInterface $shipmentDetails
      * @param ShipmentEventInterface[] $shipmentEvents
      * @param PieceInterface[]         $pieces
@@ -54,12 +60,14 @@ class TrackingInfo implements TrackingInfoInterface
     public function __construct(
         $awbNumber,
         $awbStatus,
+        $awbConditions,
         ShipmentDetailsInterface $shipmentDetails,
         array $shipmentEvents,
         array $pieces
     ) {
         $this->awbNumber = $awbNumber;
         $this->awbStatus = $awbStatus;
+        $this->awbConditions = $awbConditions;
         $this->shipmentDetails = $shipmentDetails;
         $this->shipmentEvents = $shipmentEvents;
         $this->pieces = $pieces;
@@ -88,5 +96,15 @@ class TrackingInfo implements TrackingInfoInterface
     public function getPieces()
     {
         return $this->pieces;
+    }
+
+    public function getAwbConditions()
+    {
+        return $this->awbConditions;
+    }
+
+    public function setAwbConditions($awbConditions)
+    {
+        $this->awbConditions = $awbConditions;
     }
 }

--- a/src/Webservice/Soap/TypeMapper/TrackingResponseMapper.php
+++ b/src/Webservice/Soap/TypeMapper/TrackingResponseMapper.php
@@ -81,14 +81,22 @@ class TrackingResponseMapper
                 $shipmentEvents = [];
             }
 
-            $trackingInfos[] = new TrackingInfo(
+            $trackingInfo = new TrackingInfo(
                 $soapTrackingItem->getAWBNumber(),
                 $soapTrackingItem->getStatus()->getActionStatus(),
-                $soapTrackingItem->getStatus()->getCondition(),
                 $shipmentDetails,
                 $shipmentEvents,
                 $trackingPieces
             );
+            $conditions = $soapTrackingItem->getStatus()->getCondition();
+            if(empty($conditions)){
+                $conditions = [];
+            }
+            foreach ($conditions as $condition){
+                $trackingInfo->addAwbConditions($condition->getConditionCode(), $condition->getConditionData());
+            }
+
+            $trackingInfos[] = $trackingInfo;
         }
 
         $time = strtotime($soapResponseContent->getResponse()->getServiceHeader()->getMessageTime());

--- a/src/Webservice/Soap/TypeMapper/TrackingResponseMapper.php
+++ b/src/Webservice/Soap/TypeMapper/TrackingResponseMapper.php
@@ -84,6 +84,7 @@ class TrackingResponseMapper
             $trackingInfos[] = new TrackingInfo(
                 $soapTrackingItem->getAWBNumber(),
                 $soapTrackingItem->getStatus()->getActionStatus(),
+                $soapTrackingItem->getStatus()->getCondition(),
                 $shipmentDetails,
                 $shipmentEvents,
                 $trackingPieces


### PR DESCRIPTION
On trackingRequest if awbStatus is **Failure** webservice return as some information in **Condition** array.  we can use and log this infos. but current master branch doesn't return this with tracking info.

----
[@mam08ixo]:

Example web service error response (excerpt):

```xml
<Status>
    <ActionStatus>No Shipments Found</ActionStatus>
    <Condition>
        <ArrayOfConditionItem>
            <ConditionCode>101</ConditionCode>
            <ConditionData>No Shipments Found for AWBNumber | 9876543210</ConditionData>
        </ArrayOfConditionItem>
    </Condition>
</Status>
```

The SDK includes the `ActionStatus` field with its [public response](https://github.com/netresearch/dhl-sdk-api-express/blob/2.0.1/src/Model/Response/Tracking/TrackingInfo.php#L73-L76) but omits the details.

This PR attempts to change that.