### PR TITLE
Add label options to shipment request

### DIFF
--- a/src/Api/Data/Request/Shipment/LabelOptionsInterface.php
+++ b/src/Api/Data/Request/Shipment/LabelOptionsInterface.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * See LICENSE.md for license details.
+ */
+
+namespace Dhl\Express\Api\Data\Request\Shipment;
+
+/**
+ * LabelOptions Interface.
+ *
+ * @api
+ * @author   Daniel Fairbrother <dfairbrother@datto.com>
+ * @link     https://www.datto.com
+ */
+interface LabelOptionsInterface
+{
+    /**
+     * Returns the request waybill document option.
+     *
+     * @return string
+     */
+    public function getRequestWaybillDocument();
+}

--- a/src/Model/Request/Shipment/LabelOptions.php
+++ b/src/Model/Request/Shipment/LabelOptions.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * See LICENSE.md for license details.
+ */
+
+namespace Dhl\Express\Model\Request\Shipment;
+
+use Dhl\Express\Api\Data\Request\Shipment\LabelOptionsInterface;
+
+
+/**
+ * LabelOptions Details.
+ *
+ * @author   Daniel Fairbrother <dfairbrother@datto.com>
+ * @link     https://www.datto.com
+ */
+class LabelOptions implements LabelOptionsInterface
+{
+    /**
+     * The service type.
+     *
+     * @var string
+     */
+    private $requestWaybillDocument;
+
+    /**
+     * LabelOptions constructor.
+     *
+     * @param LabelOptions $requestWaybillDocument
+     */
+    public function __construct(
+        $requestWaybillDocument
+    ) {
+        $this->requestWaybillDocument = $requestWaybillDocument;
+    }
+
+    public function getRequestWaybillDocument()
+    {
+        return (string) $this->requestWaybillDocument;
+    }
+}

--- a/src/Model/ShipmentRequest.php
+++ b/src/Model/ShipmentRequest.php
@@ -8,6 +8,7 @@ namespace Dhl\Express\Model;
 use Dhl\Express\Api\Data\Request\InsuranceInterface;
 use Dhl\Express\Api\Data\Request\PackageInterface;
 use Dhl\Express\Api\Data\Request\Shipment\DangerousGoods\DryIceInterface;
+use Dhl\Express\Api\Data\Request\Shipment\LabelOptionsInterface;
 use Dhl\Express\Api\Data\Request\Shipment\ShipmentDetailsInterface;
 use Dhl\Express\Api\Data\ShipmentRequestInterface;
 use Dhl\Express\Model\Request\Recipient;
@@ -60,6 +61,11 @@ class ShipmentRequest implements ShipmentRequestInterface
      * @var null|DryIceInterface
      */
     private $dryIce;
+
+    /**
+     * @var null|LabelOptionsInterface
+     */
+    private $labelOptions;
 
     /**
      * SoapShipmentRequest constructor.
@@ -124,6 +130,11 @@ class ShipmentRequest implements ShipmentRequestInterface
         return $this->dryIce;
     }
 
+    public function getLabelOptions()
+    {
+        return $this->labelOptions;
+    }
+
     /**
      * Sets the billing account number.
      *
@@ -162,6 +173,20 @@ class ShipmentRequest implements ShipmentRequestInterface
     public function setDryIce(DryIceInterface $dryIce)
     {
         $this->dryIce = $dryIce;
+
+        return $this;
+    }
+
+    /**
+     * Sets the label options instance.
+     *
+     * @param LabelOptionsInterface $labelOptions The label options instance
+     *
+     * @return ShipmentRequest
+     */
+    public function setLabelOptions(LabelOptionsInterface $labelOptions)
+    {
+        $this->labelOptions = $labelOptions;
 
         return $this;
     }

--- a/src/RequestBuilder/ShipmentRequestBuilder.php
+++ b/src/RequestBuilder/ShipmentRequestBuilder.php
@@ -232,6 +232,15 @@ class ShipmentRequestBuilder implements ShipmentRequestBuilderInterface
         return $this;
     }
 
+    public function setLabelOptions($requestWaybillDocument)
+    {
+        $this->data['labelOptions'] = [
+            'requestWaybillDocument' => $requestWaybillDocument
+        ];
+
+        return $this;
+    }
+
     public function setShipper(
         $countryCode,
         $postalCode,
@@ -402,6 +411,15 @@ class ShipmentRequestBuilder implements ShipmentRequestBuilderInterface
             );
 
             $request->setDryIce($dryIce);
+        }
+
+        // build label options
+        if (!empty($this->data['labelOptions'])) {
+            $labelOptions = new LabelOptions(
+                $this->data['labelOptions']['requestWaybillDocument']
+            );
+
+            $request->setLabelOptions($labelOptions);
         }
 
         $this->data = [];

--- a/src/Webservice/Soap/Type/ShipmentRequest/LabelOptions.php
+++ b/src/Webservice/Soap/Type/ShipmentRequest/LabelOptions.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * See LICENSE.md for license details.
+ */
+namespace Dhl\Express\Webservice\Soap\Type\ShipmentRequest;
+
+use Dhl\Express\Api\Data\Request\Shipment\LabelOptionsInterface;
+use Dhl\Express\Webservice\Soap\Type\ShipmentRequest\LabelOptions\RequestWaybillDocument;
+
+/**
+ * The LabelOptions section
+ *
+ * @api
+ * @author   Daniel Fairbrother <dfairbrother@datto.com>
+ * @link     https://www.datto.com
+ */
+class LabelOptions implements LabelOptionsInterface
+{
+    /**
+     * The request waybill document option.
+     *
+     * @var RequestWaybillDocument
+     */
+    private $RequestWaybillDocument;
+
+    /**
+     * Constructor.
+     *
+     * @param string $requestWaybillDocument The request waybill document (either Y/N or true/false)
+     */
+    public function __construct($requestWaybillDocument)
+    {
+        $this->setRequestWaybillDocument($requestWaybillDocument);
+    }
+
+    /**
+     * Returns the request waybill document option.
+     *
+     * @return RequestWaybillDocument
+     */
+    public function getRequestWaybillDocument()
+    {
+        return $this->RequestWaybillDocument;
+    }
+
+    /**
+     * Sets the delivery option.
+     *
+     * @param string $requestWaybillDocument The delivery option
+     *
+     * @return self
+     */
+    public function setRequestWaybillDocument($requestWaybillDocument)
+    {
+        $this->RequestWaybillDocument = $requestWaybillDocument;
+        return $this;
+    }
+}

--- a/src/Webservice/Soap/Type/ShipmentRequest/LabelOptions/RequestWaybillDocument.php
+++ b/src/Webservice/Soap/Type/ShipmentRequest/LabelOptions/RequestWaybillDocument.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * See LICENSE.md for license details.
+ */
+namespace Dhl\Express\Webservice\Soap\Type\ShipmentRequest\LabelOptions;
+
+use Dhl\Express\Webservice\Soap\Type\Common\YesNo;
+
+/**
+ * The RequestWaybillDocument field is used to indicate that you would like a copy of the waybill document
+ * the default in a ShipmentRequest in N
+ *
+ * @api
+ * @author   Daniel Fairbrother <dfairbrother@datto.com>
+ * @link     https://www.datto.com
+ */
+class RequestWaybillDocument extends YesNo
+{
+}

--- a/src/Webservice/Soap/Type/ShipmentRequest/RequestedShipment.php
+++ b/src/Webservice/Soap/Type/ShipmentRequest/RequestedShipment.php
@@ -70,6 +70,11 @@ class RequestedShipment
     private $OnDemandDeliveryOptions;
 
     /**
+     * @var null|LabelOptions
+     */
+    private $LabelOptions;
+
+    /**
      * @var Ship
      */
     private $Ship;
@@ -293,6 +298,29 @@ class RequestedShipment
     public function setOnDemandDeliveryOptions(OnDemandDeliveryOptions $onDemandDeliveryOptions)
     {
         $this->OnDemandDeliveryOptions = $onDemandDeliveryOptions;
+        return $this;
+    }
+
+    /**
+     * Returns the on demand delivery options.
+     *
+     * @return null|LabelOptions
+     */
+    public function getLabelOptions()
+    {
+        return $this->LabelOptions;
+    }
+
+    /**
+     * Sets the on demand delivery options.
+     *
+     * @param LabelOptions $LabelOptions The on demand delivery options
+     *
+     * @return self
+     */
+    public function setLabelOptions(LabelOptions $labelOptions)
+    {
+        $this->LabelOptions = $labelOptions;
         return $this;
     }
 

--- a/src/Webservice/Soap/Type/ShipmentRequest/ShipmentInfo.php
+++ b/src/Webservice/Soap/Type/ShipmentRequest/ShipmentInfo.php
@@ -134,6 +134,14 @@ class ShipmentInfo
     private $LabelTemplate;
 
     /**
+     * The LabelOptions node conveys additional label options. It is an optional field. Currently only
+     * RequestWaybillDocument is supported and it takes a value of Y/N
+     *
+     * @var null|LabelOptions
+     */
+    private $LabelOptions;
+
+    /**
      * The ArchiveLabelTemplate node conveys the label template used in the operation. It is an optional field.
      * This single value corresponds to the label template used to generate the Archive labels. Please check with
      * your DHL Express IT representative which templates meets your requirements. If this tag is not included, then
@@ -547,4 +555,28 @@ class ShipmentInfo
         $this->PaperlessTradeImage = $paperlessTradeImage;
         return $this;
     }
+
+    /**
+     * Returns the label options.
+     *
+     * @return null|LabelOptions
+     */
+    public function getLabelOptions()
+    {
+        return $this->LabelOptions;
+    }
+
+    /**
+     * Sets the label options.
+     *
+     * @param LabelOptions $LabelOptions The label options
+     *
+     * @return self
+     */
+    public function setLabelOptions(LabelOptions $labelOptions)
+    {
+        $this->LabelOptions = $labelOptions;
+        return $this;
+    }
+
 }

--- a/src/Webservice/Soap/TypeMapper/ShipmentRequestMapper.php
+++ b/src/Webservice/Soap/TypeMapper/ShipmentRequestMapper.php
@@ -17,6 +17,7 @@ use Dhl\Express\Webservice\Soap\Type\Common\UnitOfMeasurement;
 use Dhl\Express\Webservice\Soap\Type\ShipmentRequest\DangerousGoods;
 use Dhl\Express\Webservice\Soap\Type\ShipmentRequest\DangerousGoods\Content;
 use Dhl\Express\Webservice\Soap\Type\ShipmentRequest\InternationalDetail;
+use Dhl\Express\Webservice\Soap\Type\ShipmentRequest\LabelOptions;
 use Dhl\Express\Webservice\Soap\Type\ShipmentRequest\Packages;
 use Dhl\Express\Webservice\Soap\Type\ShipmentRequest\Packages\RequestedPackages;
 use Dhl\Express\Webservice\Soap\Type\ShipmentRequest\RequestedShipment;
@@ -176,6 +177,15 @@ class ShipmentRequestMapper
                         number_format($dryIce->getWeight(), 2),
                         $dryIce->getUNCode()
                     )
+                )
+            );
+        }
+
+        // Label options
+        if ($labelOptions = $request->getLabelOptions()) {
+            $requestedShipment->getShipmentInfo()->setLabelOptions(
+                new LabelOptions(
+                    $labelOptions->getRequestWaybillDocument()
                 )
             );
         }


### PR DESCRIPTION
My company had a need to always request a waybill document so I added the label options object so we could always request this.

Please let me know if there are any changes that need to be made to be more in line with this library.